### PR TITLE
chore: add test passkey signer for rust sdk

### DIFF
--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -143,3 +143,19 @@ export function toPasskeySigner(privateKey: crypto.KeyObject, credentialId: Hex)
         return concat([webauthnValidator, fatSignature]);
     }
 }
+
+// to run:
+// pnpm tsx test/integration/utils.ts --hash <HASH>
+const hashIndex = process.argv.indexOf('--hash');
+if (hashIndex !== -1) {
+    const hash = process.argv[hashIndex + 1] as Hex;
+    if (!hash.startsWith('0x') || hash.length !== 66) {
+        console.error('Invalid hash');
+        process.exit(1);
+    }
+    const credentialId = '0x2868baa08431052f6c7541392a458f64';
+    // const publicKey = {"x":"0xe0a43b9c64a2357ea7f66a0551f57442fbd32031162d9be762800864168fae40","y":"0x450875e2c28222e81eb25ae58d095a3e7ca295faa3fc26fb0e558a0b571da501"};
+    const privateKeyJSON: crypto.JsonWebKey = {"kty":"EC","x":"4KQ7nGSiNX6n9moFUfV0QvvTIDEWLZvnYoAIZBaPrkA","y":"RQh14sKCIugeslrljQlaPnyilfqj_Cb7DlWKC1cdpQE","crv":"P-256","d":"mVCuyGzW2iB7wl2Lt3waJHHzWmtc6W-lzzIvjgHVA8U"};
+    const privateKey = crypto.createPrivateKey({key: privateKeyJSON, format: 'jwk'});
+    toPasskeySigner(privateKey, credentialId)(hash).then(console.log)
+}


### PR DESCRIPTION
# Description

This is a dummy passkey signer which is used by the rust integration tests, down the line a dedicated rust passkey signer will be implemented then this can be removed. 
