### PR TITLE
chore: export 7579 types to JSON ABI

### DIFF
--- a/test/mocks/IERC7579TypeExporter.sol
+++ b/test/mocks/IERC7579TypeExporter.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Execution } from "../../src/interfaces/IERC7579Account.sol";
+
+/// @title IERC7579TypeExporter
+/// @notice Mock contract that exports Execution struct to the ABI
+/// @dev This contract exists solely to force the Solidity compiler to include
+/// the Execution struct definition in the generated ABI JSON.
+/// It should never be deployed or called in production.
+contract IERC7579TypeExporter {
+    function exportExecution(Execution calldata) external pure { }
+}


### PR DESCRIPTION
# Description

This is needed for the SDKs such that the `Execution` (and potentially in the future other types) are added to the JSON ABI.